### PR TITLE
Change gitrepo to point to use-flux-ga

### DIFF
--- a/clusters/staging/flux-system/gotk-sync.yaml
+++ b/clusters/staging/flux-system/gotk-sync.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   interval: 1m0s
   ref:
-    branch: main
+    branch: use-flux-ga
   secretRef:
     name: flux-system
   url: ssh://git@github.com/squaremo/flux2-multi-tenancy-whatif


### PR DESCRIPTION
This is so I can check what happens when I change a GitRepository definition in a PR.

As a fun side adventure, for `flux-whatif` invocations that ask "what if X was merged to main branch", this also takes the GitRepository out of being affected by the scenario (because the scenario cares about GitRepository objects specifying `main` as the branch); but, the version of the GitRepository on that branch points back at `main`! I don't even know what that should do (report a cycle?).