### PR TITLE
Retarget dev-team source at this repo

### DIFF
--- a/tenants/base/dev-team/sync.yaml
+++ b/tenants/base/dev-team/sync.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: apps
 spec:
   interval: 1m
-  url: https://github.com/fluxcd/flux2-multi-tenancy
+  url: https://github.com/squaremo/flux2-multi-tenancy-whatif
   ref:
     branch: dev-team
 ---


### PR DESCRIPTION
This is a change that can be what-ifed; if this branch is merged into `main`, then the GitRepository representing the tenant will be pointed here instead of at the template repo; and, when that happens, the Kustomization that uses it will be triggered. Since this repo has the same content as the template, there should be no further diffs.